### PR TITLE
Add UP_FLAGS optional env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # unraid-tailscale
 Docker build files for tailscale on unraid
+
+## Optional Env Vars
+
+- `UP_FLAGS` &ndash; Pass flags to the `tailscale up` command run on start-up

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,7 +18,7 @@ tailscaled --state=/state/tailscaled.state &
 sleep 10
 
 # Start the interface
-tailscale up
+tailscale up ${UP_FLAGS:-}
 
 # Do nothing until the end of time
 sleep infinity


### PR DESCRIPTION
Thank you putting together this container!

I needed one small change that would allow me to pass the flag `-advertise-routes 192.168.1.0/24` to the `tailscale up` command in the entrypoint. 

This change adds an optional `UP_FLAGS` env var which is picked up by the entrypoint and solves my issue.