### PR TITLE
Add Flags for Tailscale Deamon

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ support for this usage.
 ## Optional Env Vars
 
 - `UP_FLAGS` &ndash; Pass flags to the `tailscale up` command run on start-up
-Please note that support cannot be provided for the use of UP_FLAGS
+Please note that support cannot be provided for the use of `UP_FLAGS`
+- `DEAMON_FLAGS` &ndash; Pass flags to the `tailscaled` command run on start-up, for example to enable [Userspace Networking Mode](https://github.com/tailscale/tailscale/issues/5425)
+Please note that support cannot be provided for the use of `DEAMON_FLAGS`
 
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -12,7 +12,7 @@ if [ ! -c /dev/net/tun ]; then
 fi
 
 # Start the daemon
-/app/tailscaled --state=/state/tailscaled.state --statedir=/state/ &
+/app/tailscaled --state=/state/tailscaled.state --statedir=/state/ ${DEAMON_FLAGS:-} &
 
 # Let it get connected to the control plane
 sleep 10


### PR DESCRIPTION
This is to swap to Userspace Networking for Routing without IP-Forwarding on Unraid.

This should be a bit slower, but more secure since Networking is contained inside the userspace of the container.